### PR TITLE
Settings: Ignore externalIndex if its greater than dash category size.

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -1374,7 +1374,8 @@ public class SettingsActivity extends Activity
                         activityInfo.packageName, activityInfo.name);
                 Utils.updateTileToSpecificActivityFromMetaDataOrRemove(this, tile);
 
-                if (category.externalIndex == -1) {
+                if (category.externalIndex == -1
+                        || category.externalIndex > category.getTilesCount()) {
                     // If no location for external tiles has been specified for this category,
                     // then just put them at the end.
                     category.addTile(tile);


### PR DESCRIPTION
  Otherwise you end up with a index out of bounds exception when
  the tile is to be added.

Change-Id: I4ae6d7a3a89c1119962bc174c775a03ae382bc9b
