### PR TITLE
Settings: adapt lock screen visualizer toggle

### DIFF
--- a/res/xml/security_settings_chooser.xml
+++ b/res/xml/security_settings_chooser.xml
@@ -39,11 +39,17 @@
             android:summary="@string/owner_info_settings_summary"/>
 
         <PreferenceScreen
+            android:key="lockscreen_shortcuts_settings"
             android:title="@string/lockscreen_targets_message" >
             <intent
                 android:targetPackage="com.android.systemui"
                 android:targetClass="com.android.systemui.cm.LockscreenShortcutsActivity" />
         </PreferenceScreen>
+
+        <com.android.settings.cyanogenmod.CMSecureSettingSwitchPreference
+            android:key="lockscreen_visualizer"
+            android:title="@string/lockscreen_visualizer_title"
+            android:defaultValue="true"/>
 
     </PreferenceCategory>
 

--- a/res/xml/security_settings_lockscreen.xml
+++ b/res/xml/security_settings_lockscreen.xml
@@ -49,11 +49,6 @@
                 android:targetClass="com.android.systemui.cm.LockscreenShortcutsActivity" />
         </PreferenceScreen>
 
-        <com.android.settings.cyanogenmod.CMSecureSettingSwitchPreference
-            android:key="lockscreen_visualizer"
-            android:title="@string/lockscreen_visualizer_title"
-            android:defaultValue="true"/>
-
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
- Do not show the Visualizer toggle for Screen lock : None
- Show the Visualizer toggle for Screen lock : Swipe
- Add a missing key field (Screen lock : Swipe)

Change-Id: I460693201142f0d7d5eb34dea91f4f5db33a00d4
Signed-off-by: AdrianDC radian.dc@gmail.com
