### PR TITLE
setings: Fix livedisplay settings

### DIFF
--- a/res/layout/display_color_calibration.xml
+++ b/res/layout/display_color_calibration.xml
@@ -42,7 +42,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/color_red_text"
                 android:paddingTop="2dip"
-                settings:min="0.01"
+                settings:min="0.20"
                 settings:max="1.00"
                 settings:defaultValue="1.00"
                 settings:digits="4" />
@@ -64,7 +64,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/color_green_text"
                 android:paddingTop="2dip"
-                settings:min="0.01"
+                settings:min="0.20"
                 settings:max="1.00"
                 settings:defaultValue="1.00"
                 settings:digits="4" />
@@ -86,7 +86,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/color_blue_text"
                 android:paddingTop="2dip"
-                settings:min="0.01"
+                settings:min="0.20"
                 settings:max="1.00"
                 settings:defaultValue="1.00"
                 settings:digits="4" />

--- a/res/xml/livedisplay.xml
+++ b/res/xml/livedisplay.xml
@@ -35,21 +35,21 @@
 
         <!-- Outdoor mode / SRE -->
         <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
-                android:key="live_display_auto_outdoor_mode"
+                android:key="display_auto_outdoor_mode"
                 android:title="@string/live_display_outdoor_mode_title"
                 android:summary="@string/live_display_outdoor_mode_summary"
                 android:defaultValue="true" />
 
         <!-- Adaptive backlight -->
         <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
-                android:key="live_display_low_power"
+                android:key="display_low_power"
                 android:title="@string/live_display_low_power_title"
                 android:summary="@string/live_display_low_power_summary"
                 android:defaultValue="true" />
 
         <!-- Color enhancement -->
         <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
-                android:key="live_display_color_enhance"
+                android:key="display_color_enhance"
                 android:title="@string/live_display_enhance_color_title"
                 android:summary="@string/live_display_enhance_color_summary"
                 android:defaultValue="true"/>

--- a/src/com/android/settings/livedisplay/LiveDisplay.java
+++ b/src/com/android/settings/livedisplay/LiveDisplay.java
@@ -63,19 +63,20 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
 
     private static final String KEY_LIVE_DISPLAY = "live_display";
     private static final String KEY_LIVE_DISPLAY_AUTO_OUTDOOR_MODE =
-            "live_display_auto_outdoor_mode";
-    private static final String KEY_LIVE_DISPLAY_LOW_POWER = "live_display_low_power";
-    private static final String KEY_LIVE_DISPLAY_COLOR_ENHANCE = "live_display_color_enhance";
+            "display_auto_outdoor_mode";
+    private static final String KEY_LIVE_DISPLAY_LOW_POWER = "display_low_power";
+    private static final String KEY_LIVE_DISPLAY_COLOR_ENHANCE = "display_color_enhance";
     private static final String KEY_LIVE_DISPLAY_TEMPERATURE = "live_display_color_temperature";
 
     private static final String KEY_DISPLAY_COLOR = "color_calibration";
     private static final String KEY_DISPLAY_GAMMA = "gamma_tuning";
     private static final String KEY_SCREEN_COLOR_SETTINGS = "screencolor_settings";
 
-    public static final int MODE_DAY = 0;
+    public static final int MODE_OFF = 0;
     public static final int MODE_NIGHT = 1;
     public static final int MODE_AUTO = 2;
     public static final int MODE_OUTDOOR = 3;
+    public static final int MODE_DAY = 4;
 
     private final Handler mHandler = new Handler();
     private final SettingsObserver mObserver = new SettingsObserver();
@@ -224,10 +225,17 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
     private void updateModeSummary() {
         int mode = CMSettings.System.getIntForUser(getContentResolver(),
                 CMSettings.System.DISPLAY_TEMPERATURE_MODE,
-                MODE_DAY, UserHandle.USER_CURRENT);
+                MODE_OFF, UserHandle.USER_CURRENT);
 
         int index = ArrayUtils.indexOf(mModeValues, String.valueOf(mode));
         mLiveDisplay.setSummary(mModeSummaries[index]);
+
+        if (mDisplayTemperature != null) {
+            mDisplayTemperature.setEnabled(mode != MODE_OFF);
+        }
+        if (mOutdoorMode != null) {
+            mOutdoorMode.setEnabled(mode != MODE_OFF);
+        }
     }
 
     private void updateTemperatureSummary() {
@@ -273,9 +281,9 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
         public void register(boolean register) {
             final ContentResolver cr = getContentResolver();
             if (register) {
-                cr.registerContentObserver(DISPLAY_TEMPERATURE_DAY_URI, false, this);
-                cr.registerContentObserver(DISPLAY_TEMPERATURE_NIGHT_URI, false, this);
-                cr.registerContentObserver(DISPLAY_TEMPERATURE_MODE_URI, false, this);
+                cr.registerContentObserver(DISPLAY_TEMPERATURE_DAY_URI, false, this, UserHandle.USER_ALL);
+                cr.registerContentObserver(DISPLAY_TEMPERATURE_NIGHT_URI, false, this, UserHandle.USER_ALL);
+                cr.registerContentObserver(DISPLAY_TEMPERATURE_MODE_URI, false, this, UserHandle.USER_ALL);
             } else {
                 cr.unregisterContentObserver(this);
             }


### PR DESCRIPTION
- Since moving this to internal settings vs. kernel settings, the
  parameters were wrong and changes set via settings weren't being
  applied. Fixit.

Change-Id: I0676f6069729878b644914abe0ad0bca8a053c9e

livedisplay: Add an "off" state
- Don't force "day" to be the default state.
- Change minimum value for color calibration to 20% so blackout doesn't
  happen when all sliders are at minimum.
- Also improve a few strings to describe what day and night means.

Change-Id: Ib2a617488fffb128c8e3e9e52d64fac6b261e53d

livedisplay: Fix for multiuser

Change-Id: If0ef1da91cf5310308abf08806f7902e25080d2c
