### PR TITLE
Bluetooth: Underp "Accept all files" setting

### DIFF
--- a/src/com/android/settings/bluetooth/BluetoothSettings.java
+++ b/src/com/android/settings/bluetooth/BluetoothSettings.java
@@ -274,7 +274,7 @@ public final class BluetoothSettings extends DeviceListPreferenceFragment implem
         int textId = isDiscovering ? R.string.bluetooth_searching_for_devices :
             R.string.bluetooth_search_for_devices;
 
-        boolean isAcceptAllFilesEnabled = Settings.System.getInt(getContentResolver(),
+        boolean isAcceptAllFilesEnabled = CMSettings.System.getInt(getContentResolver(),
                 CMSettings.System.BLUETOOTH_ACCEPT_ALL_FILES, 0) == 1;
 
         menu.add(Menu.NONE, MENU_ID_SCAN, 0, textId)
@@ -316,7 +316,7 @@ public final class BluetoothSettings extends DeviceListPreferenceFragment implem
 
             case MENU_ID_ACCEPT_ALL_FILES:
                 item.setChecked(!item.isChecked());
-                Settings.System.putInt(getContentResolver(),
+                CMSettings.System.putInt(getContentResolver(),
                         CMSettings.System.BLUETOOTH_ACCEPT_ALL_FILES,
                         item.isChecked() ? 1 : 0);
                 return true;


### PR DESCRIPTION
This was reading/writing to the wrong database, making the setting
a no-op. My bad.

Still CYNGNOS-1825

Change-Id: Ibf02b186f8e19066b0113ab1c72e31164a686af1
