### PR TITLE
Use settings' theme when inflating account prefs

### DIFF
--- a/src/com/android/settings/accounts/AccountPreferenceBase.java
+++ b/src/com/android/settings/accounts/AccountPreferenceBase.java
@@ -25,6 +25,7 @@ import android.content.SyncStatusObserver;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.content.res.Resources.Theme;
+import android.content.res.ThemeConfig;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
@@ -151,8 +152,13 @@ abstract class AccountPreferenceBase extends SettingsPreferenceFragment
                     // correct text colors. Control colors will still be wrong,
                     // but there's not much we can do about it since we can't
                     // reference local color resources.
+                    final ThemeConfig themeConfig = getActivity().getResources()
+                            .getConfiguration().themeConfig;
+                    final String themePkgName = themeConfig != null
+                            ? themeConfig.getOverlayPkgNameForApp(getActivity().getPackageName())
+                            : null;
                     final Context targetCtx = getActivity().createPackageContextAsUser(
-                            desc.packageName, 0, mUserHandle);
+                            desc.packageName, themePkgName, 0, mUserHandle);
                     final Theme baseTheme = getResources().newTheme();
                     baseTheme.applyStyle(com.android.settings.R.style.Theme_SettingsBase, true);
                     final Context themedCtx = new ContextThemeWrapper(targetCtx, 0);


### PR DESCRIPTION
When inflating account specific preferences, the settings style is
set so the inflated preferences have the same style.  If a different
theme, than the rest of the system, is set for Settings it is possible
for the inflated preference to try and reference a theme specific item
which won't be part of that apps resources, resulting in an
InflateException.  To avoid this we attach the themed resources that
are applied to settings to the newly created package context so that
those resources can be properly resolved.

Change-Id: I0cf0430db379b146fe80ce3173f050e5b120bbbb
TICKET: OPO-437
