### PR TITLE
Settings: add config for new APN type defaults

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -44,6 +44,9 @@
     <!-- Config to enable/disable ppp number in APN editor -->
     <bool name="config_ppp_enabled">false</bool>
 
+    <!-- Config to set default APN type when adding a new APN -->
+    <string name="config_default_new_apn_type" translateable="false"></string>
+
     <!-- This used to define screen color's Hue progress bar minimum value -->
     <integer name="minimum_hue_value" translatable="false">0</integer>
 

--- a/src/com/android/settings/ApnEditor.java
+++ b/src/com/android/settings/ApnEditor.java
@@ -306,6 +306,7 @@ public class ApnEditor extends InstrumentedPreferenceActivity
                     mCurMnc = mnc;
                     mCurMcc = mcc;
                 }
+                mApnType.setText(checkNull(getString(R.string.config_default_new_apn_type)));
             }
             int authVal = mCursor.getInt(AUTH_TYPE_INDEX);
             if (authVal != -1) {


### PR DESCRIPTION
This way a specific mcc-mnc combo can overlay some defaults as needed.

Change-Id: I5e0c46830c1ab7845ce3372dcb06a70a144c651a
Signed-off-by: Roman Birg roman@cyngn.com
