### PR TITLE
SimDialogActivity: Check whether there is no default sub

### DIFF
--- a/src/com/android/settings/sim/SimDialogActivity.java
+++ b/src/com/android/settings/sim/SimDialogActivity.java
@@ -178,7 +178,8 @@ public class SimDialogActivity extends Activity {
                                 sir = subInfoList.get(value);
                                 SubscriptionInfo defaultSub = subscriptionManager
                                         .getDefaultDataSubscriptionInfo();
-                                if (defaultSub.getSubscriptionId() != sir.getSubscriptionId()) {
+                                if (defaultSub == null || defaultSub.getSubscriptionId()
+                                        != sir.getSubscriptionId()) {
                                     setDefaultDataSubId(context, sir.getSubscriptionId());
                                 }
                                 break;


### PR DESCRIPTION
On an out-of-the-box device, no data subscription will be
selected by default. If a single SIM is added, it will
become the default data subscription but if two sims are
added at the same time there will be no default.

In this case, this dialog will crash because it's trying
to get the subscription id from a null default. This patch
short-circuits the clause to always update if there is no
default.

Change-Id: Icd4dffaf918d43d85f807cd6a14f93abb118eca4
Ticket: CYNGNOS-1940
